### PR TITLE
Add smv_prebuild_export_pattern and smv_prebuild_export_destination options

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,6 +81,14 @@ Here are some examples:
 
         git for-each-ref --format "%(refname)" | sed 's/^refs\///g'
 
+Prebuild command
+================
+
+In some cases it may be necessary to run a command in the checked out directory before building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+
+For example:
+
+    smv_prebuild_command = "sphinx-apidoc -o docs/api mymodule"
 
 Output Directory Format
 =======================

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,10 +81,12 @@ Here are some examples:
 
         git for-each-ref --format "%(refname)" | sed 's/^refs\///g'
 
-Prebuild command
+Pre and post-build command
 ================
 
-In some cases it may be necessary to run a command in the checked out directory before building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+In some cases it may be necessary to run a command in the checked out directory before or after building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
+
+The options ``smv_prebuild_command`` and ``smv_postbuild_command`` are provided.
 
 For example:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,15 @@ This is what the default configuration looks like:
     # Determines whether remote or local git branches/tags are preferred if their output dirs conflict
     smv_prefer_remote_refs = False
 
+    # Run a command before invoking sphinx-build
+    smv_prebuild_command = 'doxygen'
+
+    # Regular expression of files and directories to export to outputdir after running smv_prebuild_command
+    smv_prebuild_export_pattern = 'doxygen$'
+
+    # Export files and directories matching smv_prebuild_export_pattern to this subdirectory of outputdir
+    smv_prebuild_export_destination = 'doxygen'
+
 You can override all of these values inside your :file:`conf.py`.
 
 .. note::
@@ -86,11 +95,34 @@ Pre and post-build command
 
 In some cases it may be necessary to run a command in the checked out directory before or after building with sphinx. For example if you are using ``sphinx-apidoc`` to generate the autodoc api source files.
 
-The options ``smv_prebuild_command`` and ``smv_postbuild_command`` are provided.
+The options ``smv_prebuild_command`` and ``smv_postbuild_command`` are provided to facilitate this, along with the ``smv_prebuild_export_pattern`` and ``smv_prebuild_export_directory`` options to allow you to optionally select which files resulting from these commands should be moved to the output directory, should it be required. Equivalents for these commands are also available in the postbuild case.
 
 For example:
 
-    smv_prebuild_command = "sphinx-apidoc -o docs/api mymodule"
+.. code-block:: python
+
+   # Run sphinx-apidoc prior to invoking sphinx-build, and place the output in the docs/api directory
+   smv_prebuild_command = "sphinx-apidoc -o docs/api mymodule"
+
+.. code-block:: python
+
+   # Run doxgen prior to running sphinx-build
+   smv_prebuild_command = "doxygen"
+   # Find the path to the directory titled 'doxygen'
+   smv_prebuild_export_pattern = 'doxygen$'
+   # Copy the doxygen build directory to the output directory
+   smv_prebuild_export_destination = 'doxygen'
+
+.. code-block:: python
+
+   # Make the doxygen generated latex files into pdfs
+   # NOTE: This directory would need to exist on all whitelisted branches and tags.
+   # More complex logic may be required in your individual use case.
+   smv_postbuild_command = "cd doxygen/latex && make"
+   # Find all files matching the pattern *.pdf
+   smv_postbuild_export_pattern = '.*.pdf'
+   # Export the matching files to the artefacts directory
+   smv_postbuild_export_destination = 'artefacts'
 
 Output Directory Format
 =======================

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -67,6 +67,7 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
                 str,
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
+            current_config.add("smv_prebuild_command", "", "html", str)
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -329,6 +330,15 @@ def main(argv=None):
                     *args.filenames,
                 ]
             )
+            current_cwd = os.path.join(data["basedir"], cwd_relative)
+            if config.smv_prebuild_command != "":
+                logger.debug(
+                    "Running prebuild command: %r", config.smv_prebuild_command
+                )
+                subprocess.check_call(
+                    config.smv_prebuild_command, cwd=current_cwd, shell=True
+                )
+
             logger.debug("Running sphinx-build with args: %r", current_argv)
             cmd = (
                 sys.executable,
@@ -337,7 +347,7 @@ def main(argv=None):
                 "sphinx",
                 *current_argv,
             )
-            current_cwd = os.path.join(data["basedir"], cwd_relative)
+
             env = os.environ.copy()
             env.update(
                 {

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -68,6 +68,7 @@ def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
             )
             current_config.add("smv_prefer_remote_refs", False, "html", bool)
             current_config.add("smv_prebuild_command", "", "html", str)
+            current_config.add("smv_postbuild_command", "", "html", str)
         current_config.pre_init_values()
         current_config.init_values()
     except Exception as err:
@@ -360,5 +361,14 @@ def main(argv=None):
                 }
             )
             subprocess.check_call(cmd, cwd=current_cwd, env=env)
+
+            if config.smv_postbuild_command != "":
+                logger.debug(
+                    "Running postbuild command: %r",
+                    config.smv_postbuild_command,
+                )
+                subprocess.check_call(
+                    config.smv_postbuild_command, cwd=current_cwd, shell=True
+                )
 
     return 0


### PR DESCRIPTION
* `smv_prebuild_export_pattern` will allow a user to specify a regular expression to identify files and folders resulting from `smv_prebuild_command` to the versioned output directory
* `smv_prebuild_export_destination` will allow the user to specify the name of a directory in the versioned output directory in which to place the files matched by `smv_prebuild_export_pattern`.
* `smv_postbuild_export_pattern` and `smv_postbuild_export_destination` also added with the same functionality as above, except applied to the results of `smv_postbuild_command`
* Add descriptions of these to the documentation, with exemplar usage.